### PR TITLE
Kitspace: Add `eda` field

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,4 +1,7 @@
 gerbers: .kitspace
 bom: .kitspace/bom.csv
 color: green
+eda:
+  type: eagle
+  pcb: hardware/xboxhdmi.brd
 site: https://github.com/Ryzee119/XboxHDMI-Ryzee119


### PR DESCRIPTION
Without this it it tries to make the assembly guide from the other .brd (and fails -- maybe something wrong with that .brd?). 